### PR TITLE
10122 inputs using updateMutation

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/inputs.py
+++ b/experimenter/experimenter/experiments/api/v5/inputs.py
@@ -33,6 +33,11 @@ class BranchInput(graphene.InputObjectType):
     screenshots = graphene.List(BranchScreenshotInput)
 
 
+class NimbusExperimentSubscriberInput(graphene.InputObjectType):
+    email = graphene.String(required=True)
+    subscribed = graphene.Boolean(required=True)
+
+
 class DocumentationLinkInput(graphene.InputObjectType):
     title = NimbusExperimentDocumentationLinkEnum(required=True)
     link = graphene.String(required=True)
@@ -95,6 +100,10 @@ class ExperimentInput(graphene.InputObjectType):
     secondary_outcomes = graphene.List(graphene.String)
     status = NimbusExperimentStatusEnum()
     status_next = NimbusExperimentStatusEnum()
+    subscribers = graphene.List(
+        graphene.NonNull(NimbusExperimentSubscriberInput),
+        required=False,
+    )
     takeaways_metric_gain = graphene.Boolean(required=False)
     takeaways_gain_amount = graphene.String()
     takeaways_qbr_learning = graphene.Boolean(required=False)

--- a/experimenter/experimenter/experiments/tests/api/v5/test_mutations.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_mutations.py
@@ -27,6 +27,7 @@ from experimenter.experiments.tests.factories import (
     NimbusFeatureConfigFactory,
     NimbusVersionedSchemaFactory,
 )
+from experimenter.openidc.tests.factories import UserFactory
 from experimenter.outcomes import Outcomes
 from experimenter.outcomes.tests import mock_valid_outcomes
 from experimenter.projects.tests.factories import ProjectFactory
@@ -1288,6 +1289,179 @@ class TestUpdateExperimentMutationSingleFeature(
             child_experiment=excluded,
             branch_slug=excluded.reference_branch.slug,
         ).get()
+
+    def test_subscribe_to_experiment_empty_subscribers(self):
+        current_user = UserFactory.create()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            subscribers=[],
+        )
+        self.assertEqual(list(experiment.subscribers.all()), [])
+
+        response = self.query(
+            UPDATE_EXPERIMENT_MUTATION,
+            variables={
+                "input": {
+                    "id": experiment.id,
+                    "name": "test subscribe",
+                    "subscribers": [
+                        {
+                            "email": current_user.email,
+                            "subscribed": True,
+                        }
+                    ],
+                    "changelogMessage": "test subscribe",
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: current_user.email},
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        content = json.loads(response.content)
+
+        result = content["data"]["updateExperiment"]
+        self.assertEqual(result["message"], "success")
+
+        experiment = NimbusExperiment.objects.get()
+        self.assertEqual(list(experiment.subscribers.all()), [current_user])
+
+    def test_subscribe_to_experiment_with_existing_subscribers(self):
+        current_user = UserFactory.create()
+        existing_subscriber = UserFactory.create()
+
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            subscribers=[existing_subscriber],
+        )
+        self.assertEqual(list(experiment.subscribers.all()), [existing_subscriber])
+
+        response = self.query(
+            UPDATE_EXPERIMENT_MUTATION,
+            variables={
+                "input": {
+                    "id": experiment.id,
+                    "subscribers": [
+                        {
+                            "email": current_user.email,
+                            "subscribed": True,
+                        }
+                    ],
+                    "changelogMessage": "test subscribe",
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: current_user.email},
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        content = json.loads(response.content)
+        result = content["data"]["updateExperiment"]
+
+        self.assertEqual(result["message"], "success")
+
+        experiment = NimbusExperiment.objects.get()
+        expected_subscribers = [current_user, existing_subscriber]
+
+        self.assertEqual(set(experiment.subscribers.all()), set(expected_subscribers))
+
+    def test_subscribe_to_experiment_that_is_already_subscribed(self):
+        current_user = UserFactory.create()
+
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            subscribers=[current_user],
+        )
+        self.assertEqual(list(experiment.subscribers.all()), [current_user])
+
+        response = self.query(
+            UPDATE_EXPERIMENT_MUTATION,
+            variables={
+                "input": {
+                    "id": experiment.id,
+                    "subscribers": [
+                        {
+                            "email": current_user.email,
+                            "subscribed": True,
+                        }
+                    ],
+                    "changelogMessage": "test subscribe",
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: current_user.email},
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        content = json.loads(response.content)
+        result = content["data"]["updateExperiment"]
+
+        self.assertEqual(result["message"], "success")
+
+        experiment = NimbusExperiment.objects.get()
+        self.assertEqual(list(experiment.subscribers.all()), [current_user])
+
+    def test_unsubscribe_to_experiment(self):
+        current_user = UserFactory.create()
+
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            subscribers=[current_user],
+        )
+        self.assertEqual(list(experiment.subscribers.all()), [current_user])
+
+        response = self.query(
+            UPDATE_EXPERIMENT_MUTATION,
+            variables={
+                "input": {
+                    "id": experiment.id,
+                    "subscribers": [
+                        {
+                            "email": current_user.email,
+                            "subscribed": False,
+                        }
+                    ],
+                    "changelogMessage": "test subscribe",
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: current_user.email},
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        content = json.loads(response.content)
+        result = content["data"]["updateExperiment"]
+
+        self.assertEqual(result["message"], "success")
+
+        experiment = NimbusExperiment.objects.get()
+        self.assertEqual(list(experiment.subscribers.all()), [])
+
+    def test_unsubscribe_to_experiment_when_not_subscribed(self):
+        current_user = UserFactory.create()
+
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE, subscribers=[]
+        )
+        self.assertEqual(list(experiment.subscribers.all()), [])
+
+        response = self.query(
+            UPDATE_EXPERIMENT_MUTATION,
+            variables={
+                "input": {
+                    "id": experiment.id,
+                    "subscribers": [
+                        {
+                            "email": current_user.email,
+                            "subscribed": False,
+                        }
+                    ],
+                    "changelogMessage": "test subscribe",
+                }
+            },
+            headers={settings.OPENIDC_EMAIL_HEADER: current_user.email},
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        content = json.loads(response.content)
+        result = content["data"]["updateExperiment"]
+
+        self.assertEqual(result["message"], "success")
+
+        experiment = NimbusExperiment.objects.get()
+        self.assertEqual(list(experiment.subscribers.all()), [])
 
 
 @mock_valid_outcomes

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_serializer.py
@@ -145,6 +145,7 @@ class TestNimbusExperimentSerializer(TestCase):
     def test_allows_empty_values_for_all_fields_existing_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
+            subscribers=[],
         )
         data = {
             "name": "",

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_subscribers_mixin.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_subscribers_mixin.py
@@ -1,0 +1,119 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from experimenter.experiments.api.v5.serializers import NimbusExperimentSerializer
+from experimenter.experiments.models import NimbusExperiment
+from experimenter.experiments.tests.factories import NimbusExperimentFactory
+from experimenter.openidc.tests.factories import UserFactory
+
+
+class TestNimbusExperimentSubscribersMixin(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+
+    def test_can_update_subscribers_with_existing_subscribers(self):
+        subscriber: User = UserFactory.create()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            subscribers=[subscriber],
+        )
+        new_subscriber: User = UserFactory.create()
+
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            {
+                "subscribers": [{"email": new_subscriber.email, "subscribed": True}],
+                "changelog_message": "Test unsubscribe",
+            },
+            context={"user": new_subscriber},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        experiment = serializer.save()
+        self.assertEqual(list(experiment.subscribers.all()), [subscriber, new_subscriber])
+
+    def test_can_update_subscribers_when_already_subscribed(self):
+        subscriber: User = UserFactory.create()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            subscribers=[subscriber],
+        )
+
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            {
+                "subscribers": [{"email": subscriber.email, "subscribed": True}],
+                "changelog_message": "Test unsubscribe",
+            },
+            context={"user": subscriber},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        experiment = serializer.save()
+        self.assertEqual(list(experiment.subscribers.all()), [subscriber])
+
+    def test_can_remove_subscribers(self):
+        subscriber = UserFactory.create()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            subscribers=[subscriber],
+        )
+
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            {
+                "subscribers": [{"email": subscriber.email, "subscribed": False}],
+                "changelog_message": "Test unsubscribe",
+            },
+            context={"user": subscriber},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        experiment = serializer.save()
+        self.assertEqual(list(experiment.subscribers.all()), [])
+
+    def test_can_remove_subscribers_with_no_existing_subscribers(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            subscribers=[],
+        )
+        new_subscriber = UserFactory.create()
+
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            {
+                "subscribers": [{"email": new_subscriber.email, "subscribed": False}],
+                "changelog_message": "Test unsubscribe",
+            },
+            context={"user": new_subscriber},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        experiment = serializer.save()
+        self.assertEqual(list(experiment.subscribers.all()), [])
+
+    def test_can_update_subscribers_with_no_existing_subscribers(self):
+        subscriber: User = UserFactory.create()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            subscribers=[],
+        )
+
+        serializer = NimbusExperimentSerializer(
+            experiment,
+            {
+                "subscribers": [{"email": subscriber.email, "subscribed": True}],
+                "changelog_message": "Test unsubscribe",
+            },
+            context={"user": subscriber},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        experiment = serializer.save()
+        self.assertEqual(list(experiment.subscribers.all()), [subscriber])

--- a/experimenter/experimenter/nimbus-ui/schema.graphql
+++ b/experimenter/experimenter/nimbus-ui/schema.graphql
@@ -563,6 +563,7 @@ input ExperimentInput {
   secondaryOutcomes: [String]
   status: NimbusExperimentStatusEnum
   statusNext: NimbusExperimentStatusEnum
+  subscribers: [NimbusExperimentSubscriberInput!]
   takeawaysMetricGain: Boolean
   takeawaysGainAmount: String
   takeawaysQbrLearning: Boolean
@@ -612,6 +613,11 @@ scalar Upload
 input NimbusExperimentBranchThroughRequiredInput {
   requiredExperiment: Int!
   branchSlug: String
+}
+
+input NimbusExperimentSubscriberInput {
+  email: String!
+  subscribed: Boolean!
 }
 
 type UpdateExperiment {

--- a/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
+++ b/experimenter/experimenter/nimbus-ui/src/types/globalTypes.ts
@@ -301,6 +301,7 @@ export interface ExperimentInput {
   secondaryOutcomes?: (string | null)[] | null;
   status?: NimbusExperimentStatusEnum | null;
   statusNext?: NimbusExperimentStatusEnum | null;
+  subscribers?: NimbusExperimentSubscriberInput[] | null;
   takeawaysMetricGain?: boolean | null;
   takeawaysGainAmount?: string | null;
   takeawaysQbrLearning?: boolean | null;
@@ -319,6 +320,11 @@ export interface NimbusExperimentBranchThroughExcludedInput {
 export interface NimbusExperimentBranchThroughRequiredInput {
   requiredExperiment: number;
   branchSlug?: string | null;
+}
+
+export interface NimbusExperimentSubscriberInput {
+  email: string;
+  subscribed: boolean;
 }
 
 //==============================================================

--- a/experimenter/tests/integration/nimbus/utils/filter_expression.js
+++ b/experimenter/tests/integration/nimbus/utils/filter_expression.js
@@ -6,13 +6,21 @@ async function remoteSettings(arguments) {
         arguments[1] - the experiment recipe
     */
 
-    const TargetingContext = ChromeUtils.import(
-        "resource://messaging-system/targeting/Targeting.jsm"
-    );
-    const ASRouterTargeting = ChromeUtils.import(
-        "resource://activity-stream/lib/ASRouterTargeting.jsm"
-    )
-    const ExperimentManager = ChromeUtils.import("resource://nimbus/lib/ExperimentManager.jsm")
+    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1868838 -
+    // ASRouterTargeting was moved from browser/components/newtab into
+    // browser/components/asrouter and its import path changed.
+    let ASRouterTargeting;
+    try {
+        ASRouterTargeting = ChromeUtils.import("resource:///modules/asrouter/ASRouterTargeting.jsm");
+    } catch (ex) {
+        if (ex.result === Cr.NS_ERROR_FILE_NOT_FOUND) {
+            ASRouterTargeting = ChromeUtils.import("resource://activity-stream/lib/ASRouterTargeting.jsm");
+        } else {
+            throw ex;
+        }
+    }
+    const ExperimentManager = ChromeUtils.importESModule("resource://nimbus/lib/ExperimentManager.sys.mjs");
+    const TargetingContext = ChromeUtils.importESModule("resource://messaging-system/targeting/Targeting.sys.mjs");
 
     const _experiment = JSON.parse(arguments[1]);
 


### PR DESCRIPTION
* The types are not quite right
* What we want is a list[User], but we can't use the `django.contrib.auth.models` `User` or `class NimbusUserType(DjangoObjectType)` from `types.py`

* subscribing works, but unsubscribing doesn't
   * the serializer is getting a list of an ordered dict with {"email": user.com} inside of it (hence `subscribers[0].values()` on lines 700 and 705 in the serializer)
   * this doesn't work with unsubscribing (see `test_unsubscribe_to_experiment`)